### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![IngeoSDK: iOS location tracking made easy (Swift & ObjC)](https://raw.githubusercontent.com/IngeoSDK/ingeo-ios-sdk/assets/IngeoSDK_logo.png)
 
 
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/IngeoSDK.svg)](https://img.shields.io/cocoapods/v/IngeoSDK.svg)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/IngeoSDK.svg)](https://img.shields.io/cocoapods/v/IngeoSDK.svg)
 [![Platform](https://img.shields.io/cocoapods/p/IngeoSDK.svg?style=flat)](http://cocoadocs.org/docsets/IngeoSDK)
 
 # IngeoSDK for iOS


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
